### PR TITLE
Refactor product_id to product_index where necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ geckodriver.log
 /results/results_algorithm/
 /results/resource_usage/
 /simulators/simulator6/data/
+/factory_data/instances_legacy\

--- a/classes/classes.py
+++ b/classes/classes.py
@@ -5,7 +5,6 @@ import time
 import pandas as pd
 import numpy as np
 
-
 from enum import Enum
 
 from classes.distributions import Distribution, get_distribution
@@ -66,7 +65,7 @@ class Activity:
 
 class Product:
     def __init__(self, id, name, activities=None, temporal_relations=None, deadline=int(), predecessors=None,
-                 successors=None):
+                 successors=None, product_index=None):
         self.id = id
         self.name = name
         self.deadline = deadline
@@ -74,6 +73,7 @@ class Product:
         self.predecessors = predecessors
         self._set_activities(activities)
         self._set_temporal_relations(temporal_relations)
+        self.product_index = product_index
 
     def add_activity(self, activity):
         """
@@ -167,6 +167,7 @@ class ProductionPlan:
         for i in range(0, len(self.product_ids)):
             product = copy.deepcopy(self.factory.products[self.product_ids[i]])
             product.deadline = self.deadlines[i]
+            product.product_index = i
             self.products.append(product)
         self.size = len(self.product_ids)
 

--- a/classes/operator.py
+++ b/classes/operator.py
@@ -12,26 +12,28 @@ class Operator:
         self.printing = printing
         self.policy_type = policy_type
 
-    def signal_failed_activity(self, product_id, activity_id, current_time):
+    def signal_failed_activity(self, product_index, activity_id, current_time):
         """
         Process signal about a failed activity
         """
         if self.printing:
-            print(f'At time {current_time}: the operator receives the signal that product {product_id} ACTIVITY '
-                  f'{activity_id} got cancelled, so we apply policy {self.policy_type}')
+            print(
+                f'At time {current_time}: the operator receives the signal that product index {product_index} with id {self.plan.products[product_index].id} ACTIVITY '
+                f'{activity_id} got cancelled, so we apply policy {self.policy_type}')
             print(f'At time {current_time}: the current plan is {self.plan.earliest_start}')
 
         if self.policy_type == 1:
             # Remove activities from plan that are from the same product_id as the cancelled activity
             if self.printing:
-                print(f'At time {current_time}: the repair policy removes all activities from product {product_id} '
+                print(f'At time {current_time}: the repair policy removes all activities from product {product_index} '
                       f'from the plan')
             for i, act in enumerate(self.plan.earliest_start):
-                if act['product_id'] == product_id:
+                if act['product_index'] == product_index:
                     del self.plan.earliest_start[i]
 
         elif self.policy_type == 2:
-            self.plan.earliest_start.append({'product_id': product_id, "activity_id": activity_id, "earliest_start": current_time + 1})
+            self.plan.earliest_start.append(
+                {'product_index': product_index, "activity_id": activity_id, "earliest_start": current_time + 1})
 
         if self.printing:
             print(f'At time {current_time}: the updated plan is {self.plan.earliest_start}')
@@ -48,7 +50,7 @@ class Operator:
         if len(self.plan.earliest_start) == 0:
             finish, send_activity = True, False
             delay = 0
-            activity_id, product_id, proc_time, needs = None, None, None, None
+            activity_id, product_index, proc_time, needs = None, None, None, None
 
         else:
             # Obtain the start time of the next activity according to the plan
@@ -64,17 +66,18 @@ class Operator:
             # Check if this activity can start now
             if earliest_start == current_time:
                 send_activity = True
-                product_id = self.plan.earliest_start[i]["product_id"]
+                product_index = self.plan.earliest_start[i]["product_index"]
                 activity_id = self.plan.earliest_start[i]["activity_id"]
 
                 # Obtain information about resource needs and processing time
-                needs = self.plan.products[product_id].activities[activity_id].needs
-                proc_time = max(self.plan.products[product_id].activities[activity_id].processing_time[0], 1)
-                #proc_time = np.ceil(proc_time)
+                needs = self.plan.products[product_index].activities[activity_id].needs
+                proc_time = max(self.plan.products[product_index].activities[activity_id].processing_time[0], 1)
+                # proc_time = np.ceil(proc_time)
 
                 if self.printing:
-                    print(f'At time {current_time}: the next event is product {product_id} ACTIVITY {activity_id}'
-                          f' and should start now')
+                    print(
+                        f'At time {current_time}: the next event is product index {product_index} with id {self.plan.products[product_index].id} ACTIVITY {activity_id}'
+                        f' and should start now')
 
                 # Remove this activity from plan
                 del self.plan.earliest_start[i]
@@ -90,6 +93,6 @@ class Operator:
             else:
                 send_activity = False
                 delay = 1
-                activity_id, product_id, proc_time, needs = None, None, None, None
+                activity_id, product_index, proc_time, needs = None, None, None, None
 
-        return send_activity, delay, activity_id, product_id, proc_time, needs, finish
+        return send_activity, delay, activity_id, product_index, proc_time, needs, finish

--- a/classes/simulator_1.py
+++ b/classes/simulator_1.py
@@ -84,7 +84,7 @@ class Simulator:
                 print(f'Product {p} released resources: {resource_names} at time: {end_time}')
 
             self.resource_usage.append({"Activity": i,
-                                        "Product": p,
+                                        "ProductIndex": p,
                                         "Resource": resource_names,
                                         "Check_resource_type": r.resource_group,
                                         "Machine_id": r.id,
@@ -133,7 +133,7 @@ class Simulator:
         tardiness = 0
 
         for p in self.plan.sequence:
-            schedule = self.resource_usage[self.resource_usage["Product"] == p]
+            schedule = self.resource_usage[self.resource_usage["ProductIndex"] == p]
             finish = max(schedule["Finish"])
             if self.printing:
                 print(f'Product {p} finished at time {finish}, while the deadline was {self.plan.products[p].deadline}.')

--- a/classes/simulator_2.py
+++ b/classes/simulator_2.py
@@ -90,7 +90,7 @@ class Simulator:
                 print(f'Product {p} released resources: {resource_names} at time: {end_time}')
 
             self.resource_usage.append({"Activity": i,
-                                        "Product": p,
+                                        "ProductIndex": p,
                                         "Resource": resource_names,
                                         "Check_resource_type": r.resource_group,
                                         "Machine_id": r.id,
@@ -139,7 +139,7 @@ class Simulator:
         tardiness = 0
 
         for p in self.plan.sequence:
-            schedule = self.resource_usage[self.resource_usage["Product"] == p]
+            schedule = self.resource_usage[self.resource_usage["ProductIndex"] == p]
             finish = max(schedule["Finish"])
             if self.printing:
                 print(f'Product {p} finished at time {finish}, while the deadline was {self.plan.products[p].deadline}.')

--- a/classes/simulator_3.py
+++ b/classes/simulator_3.py
@@ -106,7 +106,7 @@ class Simulator:
                 print(f'Product {p} released resources: {resource_names} at time: {end_time}')
 
             self.resource_usage.append({"Activity": i,
-                                        "Product": p,
+                                        "ProductIndex": p,
                                         "Resource": resource_names,
                                         "Check_resource_type": r.resource_group,
                                         "Machine_id": r.id,
@@ -157,7 +157,7 @@ class Simulator:
         tardiness = 0
 
         for p in self.plan.sequence:
-            schedule = self.resource_usage[self.resource_usage["Product"] == p]
+            schedule = self.resource_usage[self.resource_usage["ProductIndex"] == p]
             finish = max(schedule["Finish"])
             if self.printing:
                 print(f'Product {p} finished at time {finish}, while the deadline was {self.plan.products[p].deadline}.')

--- a/classes/simulator_4.py
+++ b/classes/simulator_4.py
@@ -71,7 +71,7 @@ class Simulator:
                 print(f'Product {product_id}, activity {activity_id} released resources: {resource_names} at time: {end_time}')
 
             # Store relevant information
-            self.resource_usage.append({"Product": product_id,
+            self.resource_usage.append({"ProductIndex": product_id,
                                         "Activity": activity_id,
                                         "Resource": resource_names,
                                         "Check_resource_type": r_process.resource_group,
@@ -92,7 +92,7 @@ class Simulator:
 
         # Iterate through the different activities
         for id, i in enumerate(earliest_start_times_argsort):
-            product_id = self.plan.earliest_start[i]["product_id"]
+            product_id = self.plan.earliest_start[i]["product_index"]
             activity_id = self.plan.earliest_start[i]["activity_id"]
 
             # Obtain information about resource needs and processing time
@@ -170,7 +170,7 @@ class Simulator:
         lateness = 0
 
         for p in self.plan.sequence:
-            schedule = self.resource_usage[self.resource_usage["Product"] == p]
+            schedule = self.resource_usage[self.resource_usage["ProductIndex"] == p]
             finish = max(schedule["Finish"])
             if self.printing:
                 print(f'Product {p} finished at time {finish}, while the deadline was {self.plan.products[p].deadline}.')

--- a/classes/simulator_5.py
+++ b/classes/simulator_5.py
@@ -65,7 +65,7 @@ class Simulator:
             print(f'Product {product_id}, activity {activity_id} released resources: {needs} at time: {end_time} \n')
 
             # Store relevant information
-            self.resource_usage.append({"Product": product_id,
+            self.resource_usage.append({"ProductIndex": product_id,
                                         "Activity": activity_id,
                                         "Resource": needs,
                                         "Check_resource_type": resource.resource_group,
@@ -79,7 +79,7 @@ class Simulator:
         # factory
         else:
             print(f"Since there are no resources available, ACTIVITY {activity_id} will not be processed")
-            self.resource_usage.append({"Product": product_id,
+            self.resource_usage.append({"ProductIndex": product_id,
                                         "Activity": activity_id,
                                         "Resource": needs,
                                         "Check_resource_type": "NOT PROCESSED",
@@ -100,7 +100,7 @@ class Simulator:
 
         # Iterate through the different activities
         for id, i in enumerate(earliest_start_times_argsort):
-            product_id = self.plan.earliest_start[i]["product_id"]
+            product_id = self.plan.earliest_start[i]["product_index"]
             activity_id = self.plan.earliest_start[i]["activity_id"]
 
             # Obtain information about resource needs and processing time
@@ -168,7 +168,7 @@ class Simulator:
         lateness = 0
 
         for p in self.plan.sequence:
-            schedule = self.resource_usage[self.resource_usage["Product"] == p]
+            schedule = self.resource_usage[self.resource_usage["ProductIndex"] == p]
             finish = max(schedule["Finish"])
             if self.printing:
                 print(f'Product {p} finished at time {finish}, while the deadline was {self.plan.products[p].deadline}.')

--- a/classes/simulator_7.py
+++ b/classes/simulator_7.py
@@ -22,10 +22,10 @@ class Simulator:
         self.operator = operator
         self.logger = SimulatorLogger(self.__class__.__name__)
 
-    def activity_processing(self, activity_id, product_id, proc_time, needs):
+    def activity_processing(self, activity_id, product_index, proc_time, needs):
         """
         :param activity_id: id of the activity (int)
-        :param product_id: id of the product (int)
+        :param product_index: id of the product (int)
         :param proc_time: processing time of this activity (int)
         :param resources_required: list with SimPy processes for resource requests (list)
         :param resources_names: list with the corresponding resource names (list)
@@ -46,37 +46,37 @@ class Simulator:
                 available_machines = [i.resource_group for i in self.factory.items].count(resource_names)
                 if self.printing:
                     print(
-                        f'At time {self.env.now}: we need {need} {resource_names} for product {product_id}, activity {activity_id} and currently '
+                        f'At time {self.env.now}: we need {need} {resource_names} for product index {product_index} with product id {self.plan.products[product_index].id}, activity {activity_id} and currently '
                         f'in the factory we have {available_machines} available')
                 if available_machines < need:
                     start_processing = False
 
         # Check precedence relations (check if minimal difference between start time with predecessors is satisfied)
-        predecessors = self.plan.products[product_id].predecessors[activity_id]
+        predecessors = self.plan.products[product_index].predecessors[activity_id]
         for pred_activity_id in predecessors:
-            temp_rel = self.plan.products[product_id].temporal_relations[(pred_activity_id, activity_id)]
+            temp_rel = self.plan.products[product_index].temporal_relations[(pred_activity_id, activity_id)]
             # start_pred = self.log_start_times[(product_id, pred_activity_id)]
-            start_pred_log = self.logger.fetch_latest_entry(self.plan.products[product_id].id,
+            start_pred_log = self.logger.fetch_latest_entry(self.plan.products[product_index].id,
                                                             pred_activity_id, Action.START)
             start_pred = start_pred_log.timestamp
             if start_pred is None:
                 if self.printing:
-                    print(f'At time {self.env.now}: product {product_id}, activity {activity_id} cannot start because '
-                          f' predecessors {product_id}, {pred_activity_id} did not start yet')
+                    print(f'At time {self.env.now}: product {product_index}, activity {activity_id} cannot start because '
+                          f' predecessors {product_index}, {pred_activity_id} did not start yet')
                 start_processing = False
             else:
                 if self.env.now - start_pred < temp_rel:
                     if self.printing:
                         print(
-                            f'At time {self.env.now}: product {product_id}, activity {activity_id} cannot start because '
-                            f' minimal time lag with {product_id}, {pred_activity_id} is not satisfied')
+                            f'At time {self.env.now}: product {product_index}, activity {activity_id} cannot start because '
+                            f' minimal time lag with {product_index}, {pred_activity_id} is not satisfied')
                     start_processing = False
 
-        for constraint in self.plan.products[product_id].activities[activity_id].constraints:
+        for constraint in self.plan.products[product_index].activities[activity_id].constraints:
             if (constraint.product_id, constraint.activity_id) in self.logger.active_processes:
                 start_processing = False
                 print(
-                    f'Activity {activity_id} of product {self.plan.products[product_id]} has incompatibility with activity {constraint.activity_id} of product {constraint.product_id} which is currently active')
+                    f'Activity {activity_id} of product {self.plan.products[product_index].id} has incompatibility with activity {constraint.activity_id} of product {constraint.product_id} which is currently active')
                 break
 
         # If it is available start the request and processing
@@ -84,7 +84,7 @@ class Simulator:
             self.signal_to_operator = False
             if self.printing:
                 print(
-                    f'At time {self.env.now}: product {product_id} ACTIVITY {activity_id} requested resources: {needs}')
+                    f'At time {self.env.now}: product {product_index} ACTIVITY {activity_id} requested resources: {needs}')
 
             # SimPy request
             resources = []
@@ -99,11 +99,11 @@ class Simulator:
 
             if self.printing:
                 print(
-                    f'At time {self.env.now}: product {product_id} ACTIVITY {activity_id} retrieved resources: {needs}')
+                    f'At time {self.env.now}: product {product_index} ACTIVITY {activity_id} retrieved resources: {needs}')
 
             # Trace back the moment in time that the activity starts processing
             start_time = self.env.now
-            self.logger.log_activity(self.plan.products[product_id].id,
+            self.logger.log_activity(self.plan.products[product_index].id,
                                      activity_id, Action.START, start_time)
             # self.log_start_times[(product_id, activity_id)] = start_time
 
@@ -112,7 +112,7 @@ class Simulator:
 
             # Trace back the moment in time that the activity ends processing
             end_time = self.env.now
-            self.logger.log_activity(self.plan.products[product_id].id,
+            self.logger.log_activity(self.plan.products[product_index].id,
                                      activity_id, Action.END, end_time)
 
             # Release the resources that were used during processing the activity
@@ -122,10 +122,10 @@ class Simulator:
 
             if self.printing:
                 print(
-                    f'At time {self.env.now}: product {product_id} ACTIVITY {activity_id} released resources: {needs}')
+                    f'At time {self.env.now}: product index {product_index} with id {self.plan.products[product_index].id} ACTIVITY {activity_id} released resources: {needs}')
 
-            self.resource_usage[(product_id, activity_id)] = \
-                {"Product": product_id,
+            self.resource_usage[(product_index, activity_id)] = \
+                {"ProductIndex": product_index,
                  "Activity": activity_id,
                  "Needs": needs,
                  "resources": resources,
@@ -141,8 +141,8 @@ class Simulator:
         else:
             if self.printing:
                 print(
-                    f"At time {self.env.now}: there are no resources available for product {product_id} ACTIVITY {activity_id}, so it cannot start")
-            self.operator.signal_failed_activity(product_id=product_id, activity_id=activity_id,
+                    f"At time {self.env.now}: there are no resources available for product {product_index} ACTIVITY {activity_id}, so it cannot start")
+            self.operator.signal_failed_activity(product_index=product_index, activity_id=activity_id,
                                                  current_time=self.env.now)
             self.nr_clashes += 1
 
@@ -153,11 +153,11 @@ class Simulator:
 
         # Ask operator about next activity
         while not finish:
-            send_activity, delay, activity_id, product_id, proc_time, needs, finish = \
+            send_activity, delay, activity_id, product_index, proc_time, needs, finish = \
                 self.operator.send_next_activity(current_time=self.env.now)
 
             if send_activity:
-                self.env.process(self.activity_processing(activity_id, product_id, proc_time, needs))
+                self.env.process(self.activity_processing(activity_id, product_index, proc_time, needs))
 
             # Generator object that does a time-out for a time period equal to delay value
             yield self.env.timeout(delay)
@@ -180,7 +180,7 @@ class Simulator:
         self.env = simpy.Environment()
 
         for act in self.plan.earliest_start:
-            self.resource_usage[(act["product_id"], act["activity_id"])] = {"Product": act["product_id"],
+            self.resource_usage[(act["product_index"], act["activity_id"])] = {"ProductIndex": act["product_index"],
                                                                             "Activity": act["activity_id"],
                                                                             "Needs": float("inf"),
                                                                             "resources": "NOT PROCESSED DUE TO CLASH",
@@ -221,7 +221,7 @@ class Simulator:
 
         nr_unfinished_products = 0
         for p in self.plan.sequence:
-            schedule = self.resource_usage[self.resource_usage["Product"] == p]
+            schedule = self.resource_usage[self.resource_usage["ProductIndex"] == p]
             finish = max(schedule["Finish"])
             if finish == float("inf"):
                 nr_unfinished_products += 1

--- a/classes/tests/resources-test/factory_1_scenario_1.json
+++ b/classes/tests/resources-test/factory_1_scenario_1.json
@@ -8,22 +8,22 @@
             {
                 "activity_id": 0,
                 "earliest_start": 0,
-                "product_id": 0
+                "product_index": 0
             },
             {
                 "activity_id": 1,
                 "earliest_start": 1,
-                "product_id": 0
+                "product_index": 0
             },
             {
                 "activity_id": 0,
                 "earliest_start": 2,
-                "product_id": 1
+                "product_index": 1
             },
             {
                 "activity_id": 1,
                 "earliest_start": 3,
-                "product_id": 1
+                "product_index": 1
             }
         ],
         "factory": {
@@ -470,6 +470,7 @@
                     "id": 0,
                     "name": "13133_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -936,6 +937,7 @@
                     "id": 1,
                     "name": "4584_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -1307,6 +1309,7 @@
                     "id": 2,
                     "name": "17235_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -1843,6 +1846,7 @@
                     "id": 3,
                     "name": "11901_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -2169,6 +2173,7 @@
                     "id": 4,
                     "name": "27115_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -2695,6 +2700,7 @@
                     "id": 5,
                     "name": "4631_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -3021,6 +3027,7 @@
                     "id": 6,
                     "name": "23888_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -3427,6 +3434,7 @@
                     "id": 7,
                     "name": "9938_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -3733,6 +3741,7 @@
                     "id": 8,
                     "name": "4625_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -4079,6 +4088,7 @@
                     "id": 9,
                     "name": "9973_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -4615,6 +4625,7 @@
                     "id": 10,
                     "name": "4614_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -5031,6 +5042,7 @@
                     "id": 11,
                     "name": "9973_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -5272,6 +5284,7 @@
                     "id": 12,
                     "name": "14469_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -5758,6 +5771,7 @@
                     "id": 13,
                     "name": "10998_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -6289,6 +6303,7 @@
                     "id": 14,
                     "name": "17510_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -6760,6 +6775,7 @@
                     "id": 15,
                     "name": "4584_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -7011,6 +7027,7 @@
                     "id": 16,
                     "name": "26773_5",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -7227,6 +7244,7 @@
                     "id": 17,
                     "name": "4740_5",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -7563,6 +7581,7 @@
                     "id": 18,
                     "name": "25004_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -7799,6 +7818,7 @@
                     "id": 19,
                     "name": "4564_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -8075,6 +8095,7 @@
                     "id": 20,
                     "name": "20322_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -8571,6 +8592,7 @@
                     "id": 21,
                     "name": "10998_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -9072,6 +9094,7 @@
                     "id": 22,
                     "name": "15015_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -9538,6 +9561,7 @@
                     "id": 23,
                     "name": "4762_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -9789,6 +9813,7 @@
                     "id": 24,
                     "name": "4635_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -10095,6 +10120,7 @@
                     "id": 25,
                     "name": "4589_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -10506,6 +10532,7 @@
                     "id": 26,
                     "name": "10244_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -10842,6 +10869,7 @@
                     "id": 27,
                     "name": "14469_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -11253,6 +11281,7 @@
                     "id": 28,
                     "name": "4611_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -11559,6 +11588,7 @@
                     "id": 29,
                     "name": "13106_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -12085,6 +12115,7 @@
                     "id": 30,
                     "name": "4778_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -12351,6 +12382,7 @@
                     "id": 31,
                     "name": "20348_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -12777,6 +12809,7 @@
                     "id": 32,
                     "name": "4558_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -13028,6 +13061,7 @@
                     "id": 33,
                     "name": "10996_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -13514,6 +13548,7 @@
                     "id": 34,
                     "name": "24455_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -13805,6 +13840,7 @@
                     "id": 35,
                     "name": "17272_1",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -14086,6 +14122,7 @@
                     "id": 36,
                     "name": "21132_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -14582,6 +14619,7 @@
                     "id": 37,
                     "name": "109980_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -15053,6 +15091,7 @@
                     "id": 38,
                     "name": "4631_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -15364,6 +15403,7 @@
                     "id": 39,
                     "name": "4643_2",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -15590,6 +15630,7 @@
                     "id": 40,
                     "name": "26696_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -16046,6 +16087,7 @@
                     "id": 41,
                     "name": "17235_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -16542,6 +16584,7 @@
                     "id": 42,
                     "name": "13133_3",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -17038,6 +17081,7 @@
                     "id": 43,
                     "name": "4681_4",
                     "predecessors": null,
+                    "product_index": null,
                     "successors": null,
                     "temporal_relations": [
                         {
@@ -17557,6 +17601,7 @@
                 "id": 0,
                 "name": "13133_4",
                 "predecessors": null,
+                "product_index": 0,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -18023,6 +18068,7 @@
                 "id": 1,
                 "name": "4584_3",
                 "predecessors": null,
+                "product_index": 1,
                 "successors": null,
                 "temporal_relations": [
                     {

--- a/classes/tests/resources-test/production_plan_stochastic.json
+++ b/classes/tests/resources-test/production_plan_stochastic.json
@@ -7,22 +7,22 @@
         {
             "activity_id": 0,
             "earliest_start": 0,
-            "product_id": 0
+            "product_index": 0
         },
         {
             "activity_id": 1,
             "earliest_start": 1,
-            "product_id": 0
+            "product_index": 0
         },
         {
             "activity_id": 0,
             "earliest_start": 2,
-            "product_id": 1
+            "product_index": 1
         },
         {
             "activity_id": 1,
             "earliest_start": 3,
-            "product_id": 1
+            "product_index": 1
         }
     ],
     "factory": {
@@ -469,6 +469,7 @@
                 "id": 0,
                 "name": "13133_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -935,6 +936,7 @@
                 "id": 1,
                 "name": "4584_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -1306,6 +1308,7 @@
                 "id": 2,
                 "name": "17235_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -1842,6 +1845,7 @@
                 "id": 3,
                 "name": "11901_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -2168,6 +2172,7 @@
                 "id": 4,
                 "name": "27115_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -2694,6 +2699,7 @@
                 "id": 5,
                 "name": "4631_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -3020,6 +3026,7 @@
                 "id": 6,
                 "name": "23888_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -3426,6 +3433,7 @@
                 "id": 7,
                 "name": "9938_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -3732,6 +3740,7 @@
                 "id": 8,
                 "name": "4625_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -4078,6 +4087,7 @@
                 "id": 9,
                 "name": "9973_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -4614,6 +4624,7 @@
                 "id": 10,
                 "name": "4614_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -5030,6 +5041,7 @@
                 "id": 11,
                 "name": "9973_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -5271,6 +5283,7 @@
                 "id": 12,
                 "name": "14469_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -5757,6 +5770,7 @@
                 "id": 13,
                 "name": "10998_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -6288,6 +6302,7 @@
                 "id": 14,
                 "name": "17510_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -6759,6 +6774,7 @@
                 "id": 15,
                 "name": "4584_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -7010,6 +7026,7 @@
                 "id": 16,
                 "name": "26773_5",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -7226,6 +7243,7 @@
                 "id": 17,
                 "name": "4740_5",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -7562,6 +7580,7 @@
                 "id": 18,
                 "name": "25004_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -7798,6 +7817,7 @@
                 "id": 19,
                 "name": "4564_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -8074,6 +8094,7 @@
                 "id": 20,
                 "name": "20322_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -8570,6 +8591,7 @@
                 "id": 21,
                 "name": "10998_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -9071,6 +9093,7 @@
                 "id": 22,
                 "name": "15015_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -9537,6 +9560,7 @@
                 "id": 23,
                 "name": "4762_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -9788,6 +9812,7 @@
                 "id": 24,
                 "name": "4635_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -10094,6 +10119,7 @@
                 "id": 25,
                 "name": "4589_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -10505,6 +10531,7 @@
                 "id": 26,
                 "name": "10244_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -10841,6 +10868,7 @@
                 "id": 27,
                 "name": "14469_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -11252,6 +11280,7 @@
                 "id": 28,
                 "name": "4611_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -11558,6 +11587,7 @@
                 "id": 29,
                 "name": "13106_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -12084,6 +12114,7 @@
                 "id": 30,
                 "name": "4778_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -12350,6 +12381,7 @@
                 "id": 31,
                 "name": "20348_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -12776,6 +12808,7 @@
                 "id": 32,
                 "name": "4558_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -13027,6 +13060,7 @@
                 "id": 33,
                 "name": "10996_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -13513,6 +13547,7 @@
                 "id": 34,
                 "name": "24455_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -13804,6 +13839,7 @@
                 "id": 35,
                 "name": "17272_1",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -14085,6 +14121,7 @@
                 "id": 36,
                 "name": "21132_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -14581,6 +14618,7 @@
                 "id": 37,
                 "name": "109980_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -15052,6 +15090,7 @@
                 "id": 38,
                 "name": "4631_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -15363,6 +15402,7 @@
                 "id": 39,
                 "name": "4643_2",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -15589,6 +15629,7 @@
                 "id": 40,
                 "name": "26696_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -16045,6 +16086,7 @@
                 "id": 41,
                 "name": "17235_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -16541,6 +16583,7 @@
                 "id": 42,
                 "name": "13133_3",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -17037,6 +17080,7 @@
                 "id": 43,
                 "name": "4681_4",
                 "predecessors": null,
+                "product_index": null,
                 "successors": null,
                 "temporal_relations": [
                     {
@@ -17556,6 +17600,7 @@
             "id": 0,
             "name": "13133_4",
             "predecessors": null,
+            "product_index": 0,
             "successors": null,
             "temporal_relations": [
                 {
@@ -18022,6 +18067,7 @@
             "id": 1,
             "name": "4584_3",
             "predecessors": null,
+            "product_index": 1,
             "successors": null,
             "temporal_relations": [
                 {

--- a/classes/tests/simulator/test_simulator_7.py
+++ b/classes/tests/simulator/test_simulator_7.py
@@ -1,0 +1,66 @@
+import unittest
+from classes.classes import Factory, CompatibilityConstraint
+from classes.classes import Product
+from classes.classes import Activity
+import pandas as pd
+from classes.classes import ProductionPlan
+from classes.distributions import NormalDistribution
+from classes.simulator_7 import Simulator
+from classes.operator import Operator
+
+
+# Set up a factory
+
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        my_factory = Factory(name="Myfactory", resource_names=["Filter", "Mixer", "Dryer"], capacity=[1, 1, 1])
+        # set id which is not index for testing
+
+        product = Product(name="Enzyme_1", id=7)
+        activity0 = Activity(id=0, processing_time=[4, 4], product="Enzyme_1",
+                             product_id="0", needs=[1, 0, 1], distribution=NormalDistribution(4, 2))
+        activity1 = Activity(id=1, processing_time=[5, 5], product="Enzyme_1",
+                             product_id="0", needs=[0, 1, 0], distribution=NormalDistribution(5, 2))
+        product.add_activity(activity=activity0)
+        product.add_activity(activity=activity1)
+        product.set_temporal_relations(temporal_relations={(0, 1): 4})
+        my_factory.add_product(product=product)
+        activity0 = Activity(id=0, processing_time=[3, 3], product="Enzyme_2",
+                             product_id="7", needs=[1, 0, 1])
+        activity1 = Activity(id=1, processing_time=[6, 6], product="Enzyme_2",
+                             product_id="7", needs=[0, 1, 1])
+
+        activity0.constraints = [CompatibilityConstraint(7, 0)]
+        product = Product(name="Enzyme_2", id=1)
+        product.add_activity(activity=activity0)
+        product.add_activity(activity=activity1)
+        product.set_temporal_relations(temporal_relations={(0, 1): 1})
+        my_factory.add_product(product=product)
+        # Set up a production plan for this factory
+        my_productionplan = ProductionPlan(id=0, size=2, name="ProductionPlanJanuary", factory=my_factory,
+                                           product_ids=[0, 1], deadlines=[8, 20])
+        my_productionplan.list_products()
+
+        # Define partial schedule that includes earliest start times
+        earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                          {"product_index": 0, "activity_id": 1, "earliest_start": 1},
+                          {"product_index": 1, "activity_id": 0, "earliest_start": 2},
+                          {"product_index": 1, "activity_id": 1, "earliest_start": 4}]
+        my_productionplan.set_earliest_start_times(earliest_start)
+
+        scenario = my_productionplan.create_scenario(0)
+
+        # Here you can choose policy 1 or policy 2
+        operator = Operator(plan=scenario.production_plan, policy_type=1, printing=True)
+        my_simulator = Simulator(plan=scenario.production_plan, operator=operator, printing=False)
+        makespan, lateness, nr_unfinished = my_simulator.simulate(sim_time=1000, random_seed=1, write=False, )
+
+        self.assertEqual(int(makespan), 7)
+        self.assertEqual(lateness, 0)
+        self.assertEqual(nr_unfinished, 0)
+        self.assertEqual(my_simulator.nr_clashes, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/classes/tests/test_production_plan.py
+++ b/classes/tests/test_production_plan.py
@@ -16,10 +16,10 @@ my_productionplan.list_products()
 my_productionplan.set_sequence(sequence=[0, 1])
 
 # This is the new format for the simulator input
-earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 0, "activity_id": 1, "earliest_start": 1},
-                  {"product_id": 1, "activity_id": 0, "earliest_start": 2},
-                  {"product_id": 1, "activity_id": 1, "earliest_start": 3}]
+earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 0, "activity_id": 1, "earliest_start": 1},
+                  {"product_index": 1, "activity_id": 0, "earliest_start": 2},
+                  {"product_index": 1, "activity_id": 1, "earliest_start": 3}]
 my_productionplan.set_earliest_start_times(earliest_start)
 
 

--- a/classes/tests/test_scenario.py
+++ b/classes/tests/test_scenario.py
@@ -20,10 +20,10 @@ class TestScenarioCreation(unittest.TestCase):
         my_productionplan.set_sequence(sequence=[0, 1])
 
         # This is the new format for the simulator input
-        earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                          {"product_id": 0, "activity_id": 1, "earliest_start": 1},
-                          {"product_id": 1, "activity_id": 0, "earliest_start": 2},
-                          {"product_id": 1, "activity_id": 1, "earliest_start": 3}]
+        earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                          {"product_index": 0, "activity_id": 1, "earliest_start": 1},
+                          {"product_index": 1, "activity_id": 0, "earliest_start": 2},
+                          {"product_index": 1, "activity_id": 1, "earliest_start": 3}]
         my_productionplan.set_earliest_start_times(earliest_start)
 
         return my_productionplan

--- a/results/cp_model/10_1_factory_1.csv
+++ b/results/cp_model/10_1_factory_1.csv
@@ -1,4 +1,4 @@
-;Task;earliest_start;End;product_id;activity_id
+;Task;earliest_start;End;product_index;activity_id
 0;12;832;929;0;12
 1;10;821;840;0;10
 2;11;813;840;0;11

--- a/results/cp_model/10_1_factory_1_infeasible.csv
+++ b/results/cp_model/10_1_factory_1_infeasible.csv
@@ -1,4 +1,4 @@
-,Task,Earliest_start,End,Product_ID,Activity_ID
+,Task,Earliest_start,End,product_index,activity_id
 0,0,100,809,0,0
 1,1,100,721,0,1
 2,2,100,791,0,2

--- a/simulators/older_versions/minimal_example_simulator_4.py
+++ b/simulators/older_versions/minimal_example_simulator_4.py
@@ -39,10 +39,10 @@ my_productionplan.list_products()
 my_productionplan.set_sequence(sequence=[0, 1])
 
 # This is the new format for the simulator input
-earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 0, "activity_id": 1, "earliest_start": 4},
-                  {"product_id": 1, "activity_id": 0, "earliest_start": 8},
-                  {"product_id": 1, "activity_id": 1, "earliest_start": 9}]
+earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 0, "activity_id": 1, "earliest_start": 4},
+                  {"product_index": 1, "activity_id": 0, "earliest_start": 8},
+                  {"product_index": 1, "activity_id": 1, "earliest_start": 9}]
 my_productionplan.set_earliest_start_times(earliest_start)
 
 # Import the new simulator

--- a/simulators/older_versions/minimal_example_simulator_5.py
+++ b/simulators/older_versions/minimal_example_simulator_5.py
@@ -39,10 +39,10 @@ my_productionplan.list_products()
 my_productionplan.set_sequence(sequence=[0, 1])
 
 # This is the new format for the simulator input
-earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 0, "activity_id": 1, "earliest_start": 4},
-                  {"product_id": 1, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 1, "activity_id": 1, "earliest_start": 1}]
+earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 0, "activity_id": 1, "earliest_start": 4},
+                  {"product_index": 1, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 1, "activity_id": 1, "earliest_start": 1}]
 my_productionplan.set_earliest_start_times(earliest_start)
 
 # Import the new simulator

--- a/simulators/simulator6/data/factory_1_scenario_1.json
+++ b/simulators/simulator6/data/factory_1_scenario_1.json
@@ -8,12 +8,12 @@
             {
                 "activity_id": 0,
                 "earliest_start": 0,
-                "product_id": 0
+                "product_index": 0
             },
             {
                 "activity_id": 1,
                 "earliest_start": 1,
-                "product_id": 0
+                "product_index": 0
             },
             {
                 "activity_id": 0,

--- a/simulators/simulator6/minimal_example_simulator_6.py
+++ b/simulators/simulator6/minimal_example_simulator_6.py
@@ -40,10 +40,10 @@ my_productionplan.list_products()
 my_productionplan.set_sequence(sequence=[0, 1])
 
 # This is the new format for the simulator input
-earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 0, "activity_id": 1, "earliest_start": 4},
-                  {"product_id": 1, "activity_id": 0, "earliest_start": 2},
-                  {"product_id": 1, "activity_id": 1, "earliest_start": 3}]
+earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 0, "activity_id": 1, "earliest_start": 4},
+                  {"product_index": 1, "activity_id": 0, "earliest_start": 2},
+                  {"product_index": 1, "activity_id": 1, "earliest_start": 3}]
 my_productionplan.set_earliest_start_times(earliest_start)
 
 # Import the new simulator

--- a/simulators/simulator6/minimal_example_simulator_6_a.py
+++ b/simulators/simulator6/minimal_example_simulator_6_a.py
@@ -23,10 +23,10 @@ my_productionplan.list_products()
 my_productionplan.set_sequence(sequence=[0, 1])
 
 # This is the new format for the simulator input
-earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 0, "activity_id": 1, "earliest_start": 1},
-                  {"product_id": 1, "activity_id": 0, "earliest_start": 2},
-                  {"product_id": 1, "activity_id": 1, "earliest_start": 3}]
+earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 0, "activity_id": 1, "earliest_start": 1},
+                  {"product_index": 1, "activity_id": 0, "earliest_start": 2},
+                  {"product_index": 1, "activity_id": 1, "earliest_start": 3}]
 my_productionplan.set_earliest_start_times(earliest_start)
 
 # create scenario and store

--- a/simulators/simulator7/minimal_example_simulator_7.py
+++ b/simulators/simulator7/minimal_example_simulator_7.py
@@ -39,10 +39,10 @@ my_productionplan = ProductionPlan(id=0, size=2, name="ProductionPlanJanuary", f
 my_productionplan.list_products()
 
 # Define partial schedule that includes earliest start times
-earliest_start = [{"product_id": 0, "activity_id": 0, "earliest_start": 0},
-                  {"product_id": 0, "activity_id": 1, "earliest_start": 1},
-                  {"product_id": 1, "activity_id": 0, "earliest_start": 2},
-                  {"product_id": 1, "activity_id": 1, "earliest_start": 4}]
+earliest_start = [{"product_index": 0, "activity_id": 0, "earliest_start": 0},
+                  {"product_index": 0, "activity_id": 1, "earliest_start": 1},
+                  {"product_index": 1, "activity_id": 0, "earliest_start": 2},
+                  {"product_index": 1, "activity_id": 1, "earliest_start": 4}]
 my_productionplan.set_earliest_start_times(earliest_start)
 
 # Here you can choose policy 1 or policy 2


### PR DESCRIPTION
- Convert product_id to project_index where necessary
- Resource usage ["Product"] is not resource usage{"ProductIndex"] for simulator output storage